### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN set -x \
         libtool \
         make \
         nasm \
+        libpng-dev \
     && npm install --production \
     && apk del .build-dependencies
 


### PR DESCRIPTION
This PR adds missing dependency `libpng-dev` to Dockerfile